### PR TITLE
Improve button focus visibility

### DIFF
--- a/ImageRole.js
+++ b/ImageRole.js
@@ -1,0 +1,22 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = void 0;
+var ImageRole = {
+  relatedConcepts: [{
+    module: 'ARIA',
+    concept: {
+      name: 'img'
+    }
+  }, {
+    module: 'HTML',
+    concept: {
+      name: 'img'
+    }
+  }],
+  type: 'structure'
+};
+var _default = ImageRole;
+exports["default"] = _default;


### PR DESCRIPTION
Improve keyboard accessibility by making the button focus state more visible. Update button CSS to use a 2px solid accent color with higher contrast and switch to :focus-visible (remove outline: none) so focus is preserved for keyboard/assistive users.